### PR TITLE
Support replacements for translation objects

### DIFF
--- a/build/lib/I18n.js
+++ b/build/lib/I18n.js
@@ -73,7 +73,16 @@ exports.default = {
   l: function l(value, options) {
     return this._localize(value, options);
   },
+  _replace: function _replace(translation, replacements) {
+    var replaced = translation;
+    Object.keys(replacements).forEach(function (replacement) {
+      replaced = replaced.split('%{' + replacement + '}').join(replacements[replacement]);
+    });
+    return replaced;
+  },
   _translate: function _translate(key) {
+    var _this = this;
+
     var replacements = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
     var translation = '';
@@ -82,8 +91,11 @@ exports.default = {
     } catch (err) {
       return (0, _formatMissingTranslation2.default)(key);
     }
-    Object.keys(replacements).forEach(function (replacement) {
-      translation = translation.split('%{' + replacement + '}').join(replacements[replacement]);
+    if (typeof translation === 'string') {
+      return this._replace(translation, replacements);
+    }
+    Object.keys(translation).forEach(function (translationKey) {
+      translation[translationKey] = _this._replace(translation[translationKey], replacements);
     });
     return translation;
   },

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -61,6 +61,13 @@ export default {
     return this._localize(value, options);
   },
 
+  _replace(translation, replacements) {
+    let replaced = translation;
+    Object.keys(replacements).forEach(replacement => {
+      replaced = replaced.split(`%{${replacement}}`).join(replacements[replacement]);
+    });
+    return replaced;
+  },
   _translate(key, replacements = {}) {
     let translation = '';
     try {
@@ -72,8 +79,11 @@ export default {
     } catch (err) {
       return formatMissingTranslation(key);
     }
-    Object.keys(replacements).forEach(replacement => {
-      translation = translation.split(`%{${replacement}}`).join(replacements[replacement]);
+    if (typeof translation === 'string') {
+      return this._replace(translation, replacements);
+    }
+    Object.keys(translation).forEach(translationKey => {
+      translation[translationKey] = this._replace(translation[translationKey], replacements);
     });
     return translation;
   },


### PR DESCRIPTION
Using replacements can handle fetching translation objects.

### Example

Imagine you have translations for option tags, something like this:

```json
{
  "split_options": {
      "one_third": "I'm fine with one third of the sum, %{one_third} sounds fine to me.",
      "half": "Let's split it. Both of us get %{half}.",
      "all": "I want to get the whole %{all}!"
     }
}
```

With the patch, you can easily fetch them with something like

```javascript
I18n.t('split_options', calculatedSums)
```

…and iterate over them to generate option tags.