### PR TITLE
Fall back to using the language-only locale when translating

### DIFF
--- a/build/lib/I18n.js
+++ b/build/lib/I18n.js
@@ -78,7 +78,8 @@ exports.default = {
 
     var translation = '';
     try {
-      translation = this._fetchTranslation(this._translations, this._locale + '.' + key, replacements.count);
+      var translationLocale = this._translations[this._locale] ? this._locale : this._locale.split('-')[0];
+      translation = this._fetchTranslation(this._translations, translationLocale + '.' + key, replacements.count);
     } catch (err) {
       return (0, _formatMissingTranslation2.default)(key);
     }

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -64,9 +64,12 @@ export default {
   _translate(key, replacements = {}) {
     let translation = '';
     try {
+      const translationLocale = this._translations[this._locale] ?
+        this._locale :
+        this._locale.split('-')[0];
       translation = this._fetchTranslation(
         this._translations,
-        `${this._locale}.${key}`,
+        `${translationLocale}.${key}`,
         replacements.count
       );
     } catch (err) {


### PR DESCRIPTION
When the locale is country specific (such as 'de-CH'), fall back to the language-only locale when translating.

```javascript
I18n.loadTranslations({ de: { very_good: 'Sehr gut!' } })
I18n.setLocale('de-CH')
I18n.l(100000)
// => "100'000"
I18n.t('very_good')
// => "Sehr gut!"
```