### PR TITLE
function for handling missing key in translation  

### DIFF
--- a/build/lib/I18n.js
+++ b/build/lib/I18n.js
@@ -50,7 +50,7 @@ exports.default = {
   },
 
   setLocale: function setLocale(locale) {
-    var rerenderComponents = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
+    var rerenderComponents = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
 
     this._locale = locale;
     if (rerenderComponents) {
@@ -58,7 +58,7 @@ exports.default = {
     }
   },
   setTranslations: function setTranslations(translations) {
-    var rerenderComponents = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
+    var rerenderComponents = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
 
     this._translations = translations;
     if (rerenderComponents) {
@@ -92,7 +92,7 @@ exports.default = {
     this._handleMissingTranslation = fn;
   },
   t: function t(key) {
-    var replacements = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var replacements = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
     return this._translate(key, replacements);
   },
@@ -115,7 +115,7 @@ exports.default = {
     return replaced;
   },
   _translate: function _translate(key) {
-    var replacements = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var replacements = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
     var translation = '';
     try {
@@ -127,7 +127,7 @@ exports.default = {
     return this._replace(translation, replacements);
   },
   _localize: function _localize(value) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
     if (options.dateFormat) {
       _moment2.default.locale(this._locale);
@@ -146,7 +146,7 @@ exports.default = {
     return value;
   },
   _fetchTranslation: function _fetchTranslation(translations, key) {
-    var count = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
+    var count = arguments.length <= 2 || arguments[2] === undefined ? null : arguments[2];
 
     var _index = key.indexOf('.');
     if (typeof translations === 'undefined') {
@@ -173,4 +173,4 @@ exports.default = {
   forceComponentsUpdate: function forceComponentsUpdate() {
     _Base2.default.rerenderAll();
   }
-};
+}; /* eslint no-underscore-dangle: "off" */

--- a/build/lib/I18n.js
+++ b/build/lib/I18n.js
@@ -24,11 +24,14 @@ var _Base2 = _interopRequireDefault(_Base);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+var handleMissingTranslation = _formatMissingTranslation2.default; /* eslint no-underscore-dangle: "off" */
+
 exports.default = {
   _localeKey: 'en',
   _translationsObject: {},
   _getTranslations: null,
   _getLocale: null,
+  _handleMissingTranslation: handleMissingTranslation,
 
   get _translations() {
     return this._getTranslations ? this._getTranslations() : this._translationsObject;
@@ -47,7 +50,7 @@ exports.default = {
   },
 
   setLocale: function setLocale(locale) {
-    var rerenderComponents = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
+    var rerenderComponents = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
 
     this._locale = locale;
     if (rerenderComponents) {
@@ -55,7 +58,7 @@ exports.default = {
     }
   },
   setTranslations: function setTranslations(translations) {
-    var rerenderComponents = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
+    var rerenderComponents = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
 
     this._translations = translations;
     if (rerenderComponents) {
@@ -82,8 +85,14 @@ exports.default = {
     }
     this._getLocale = fn;
   },
+  setHandleMissingTranslation: function setHandleMissingTranslation(fn) {
+    if (typeof fn !== 'function') {
+      throw new Error('Handle missing translation must be a function');
+    }
+    this._handleMissingTranslation = fn;
+  },
   t: function t(key) {
-    var replacements = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+    var replacements = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
     return this._translate(key, replacements);
   },
@@ -106,19 +115,19 @@ exports.default = {
     return replaced;
   },
   _translate: function _translate(key) {
-    var replacements = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+    var replacements = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
     var translation = '';
     try {
       var translationLocale = this._translations[this._locale] ? this._locale : this._locale.split('-')[0];
       translation = this._fetchTranslation(this._translations, translationLocale + '.' + key, replacements.count);
     } catch (err) {
-      return (0, _formatMissingTranslation2.default)(key);
+      return this._handleMissingTranslation(key);
     }
     return this._replace(translation, replacements);
   },
   _localize: function _localize(value) {
-    var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
     if (options.dateFormat) {
       _moment2.default.locale(this._locale);
@@ -137,7 +146,7 @@ exports.default = {
     return value;
   },
   _fetchTranslation: function _fetchTranslation(translations, key) {
-    var count = arguments.length <= 2 || arguments[2] === undefined ? null : arguments[2];
+    var count = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
 
     var _index = key.indexOf('.');
     if (typeof translations === 'undefined') {
@@ -164,4 +173,4 @@ exports.default = {
   forceComponentsUpdate: function forceComponentsUpdate() {
     _Base2.default.rerenderAll();
   }
-}; /* eslint no-underscore-dangle: "off" */
+};

--- a/example.js
+++ b/example.js
@@ -57,8 +57,6 @@ function AwesomeComponent() {
       <Translate value="export" count={1} />
       <br />
       <Translate value="export" count={2} />
-      <br />
-      <Translate value="noKey" />
     </div>
   );
 }

--- a/example.js
+++ b/example.js
@@ -57,6 +57,8 @@ function AwesomeComponent() {
       <Translate value="export" count={1} />
       <br />
       <Translate value="export" count={2} />
+      <br />
+      <Translate value="noKey" />
     </div>
   );
 }

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -5,12 +5,13 @@ import 'moment/min/locales';
 import IntlPolyfill from 'intl';
 import formatMissingTranslation from './formatMissingTranslation';
 import BaseComponent from './Base';
-
+let handleMissingTranslation = formatMissingTranslation
 export default {
   _localeKey: 'en',
   _translationsObject: {},
   _getTranslations: null,
   _getLocale: null,
+  _handleMissingTranslation: handleMissingTranslation,
 
   get _translations() {
     return this._getTranslations ? this._getTranslations() : this._translationsObject;
@@ -62,7 +63,12 @@ export default {
     }
     this._getLocale = fn;
   },
-
+  setHandleMissingTranslation(fn) {
+    if (typeof fn !== 'function') {
+      throw new Error('Handle missing translation must be a function');
+    }
+    this._handleMissingTranslation = fn
+  },
   t(key, replacements = {}) {
     return this._translate(key, replacements);
   },
@@ -97,7 +103,7 @@ export default {
         replacements.count
       );
     } catch (err) {
-      return formatMissingTranslation(key);
+      return this._handleMissingTranslation(key);
     }
     return this._replace(translation, replacements);
   },

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -5,7 +5,9 @@ import 'moment/min/locales';
 import IntlPolyfill from 'intl';
 import formatMissingTranslation from './formatMissingTranslation';
 import BaseComponent from './Base';
-let handleMissingTranslation = formatMissingTranslation
+
+const handleMissingTranslation = formatMissingTranslation;
+
 export default {
   _localeKey: 'en',
   _translationsObject: {},
@@ -67,7 +69,7 @@ export default {
     if (typeof fn !== 'function') {
       throw new Error('Handle missing translation must be a function');
     }
-    this._handleMissingTranslation = fn
+    this._handleMissingTranslation = fn;
   },
   t(key, replacements = {}) {
     return this._translate(key, replacements);


### PR DESCRIPTION
added the option to override the 'formatMissingTranslation' function .
The 'formatMissingTranslation' stays the default for a missing key but if you want to use other function you just need set the 'setHandleMissingTranslation' with your own function that handles the missing key. 

example : 
I18n.setHandleMissingTranslation(function (key) { 
  console.error(`key is missing ${key}`);
 return key;
});