### PR TITLE
pass replacements into the missing translation handler, add an example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-node_modules
-npm-debug.log
+/node_modules
+/npm-debug.log
+/yarn.lock

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -105,7 +105,7 @@ export default {
         replacements.count
       );
     } catch (err) {
-      return this._handleMissingTranslation(key);
+      return this._handleMissingTranslation(key, replacements);
     }
     return this._replace(translation, replacements);
   },


### PR DESCRIPTION
I think the missing translation handler should accept an replacements as well