### PR TITLE
Add className attribute

### DIFF
--- a/build/lib/Localize.js
+++ b/build/lib/Localize.js
@@ -42,11 +42,14 @@ var Localize = function (_BaseComponent) {
     return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Localize.__proto__ || Object.getPrototypeOf(Localize)).call.apply(_ref, [this].concat(args))), _this), _this.render = function () {
       var localization = _I18n2.default._localize(_this.props.value, _this.props.dateFormat ? { dateFormat: _this.props.dateFormat } : _this.props.options);
       if (_this.props.dangerousHTML) {
-        return _react2.default.createElement('span', { style: _this.props.style, dangerouslySetInnerHTML: { __html: localization } });
+        return _react2.default.createElement('span', { style: _this.props.style,
+          className: _this.props.className,
+          dangerouslySetInnerHTML: { __html: localization } });
       }
       return _react2.default.createElement(
         'span',
-        { style: _this.props.style },
+        { style: _this.props.style,
+          className: _this.props.className },
         localization
       );
     }, _temp), _possibleConstructorReturn(_this, _ret);
@@ -59,6 +62,7 @@ Localize.propTypes = {
   value: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.number, _react2.default.PropTypes.object]).isRequired,
   options: _react2.default.PropTypes.object,
   dateFormat: _react2.default.PropTypes.string,
+  className: _react2.default.PropTypes.string,
   dangerousHTML: _react2.default.PropTypes.bool,
   /**
    * Optional styling

--- a/build/lib/Localize.js
+++ b/build/lib/Localize.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -29,31 +31,28 @@ var Localize = function (_BaseComponent) {
   _inherits(Localize, _BaseComponent);
 
   function Localize() {
-    var _ref;
-
-    var _temp, _this, _ret;
-
     _classCallCheck(this, Localize);
 
-    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-      args[_key] = arguments[_key];
-    }
+    return _possibleConstructorReturn(this, (Localize.__proto__ || Object.getPrototypeOf(Localize)).apply(this, arguments));
+  }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Localize.__proto__ || Object.getPrototypeOf(Localize)).call.apply(_ref, [this].concat(args))), _this), _this.render = function () {
-      var localization = _I18n2.default._localize(_this.props.value, _this.props.dateFormat ? { dateFormat: _this.props.dateFormat } : _this.props.options);
-      if (_this.props.dangerousHTML) {
-        return _react2.default.createElement('span', { style: _this.props.style,
-          className: _this.props.className,
+  _createClass(Localize, [{
+    key: 'render',
+    value: function render() {
+      var localization = _I18n2.default._localize(this.props.value, this.props.dateFormat ? { dateFormat: this.props.dateFormat } : this.props.options);
+      if (this.props.dangerousHTML) {
+        return _react2.default.createElement('span', { style: this.props.style,
+          className: this.props.className,
           dangerouslySetInnerHTML: { __html: localization } });
       }
       return _react2.default.createElement(
         'span',
-        { style: _this.props.style,
-          className: _this.props.className },
+        { style: this.props.style,
+          className: this.props.className },
         localization
       );
-    }, _temp), _possibleConstructorReturn(_this, _ret);
-  }
+    }
+  }]);
 
   return Localize;
 }(_Base2.default);

--- a/build/lib/Translate.js
+++ b/build/lib/Translate.js
@@ -48,11 +48,14 @@ var Translate = function (_BaseComponent) {
     }, _this.render = function () {
       var translation = _I18n2.default._translate(_this.props.value, _this.otherProps());
       if (_this.props.dangerousHTML) {
-        return _react2.default.createElement('span', { style: _this.props.style, dangerouslySetInnerHTML: { __html: translation } });
+        return _react2.default.createElement('span', { style: _this.props.style,
+          className: _this.props.className,
+          dangerouslySetInnerHTML: { __html: translation } });
       }
       return _react2.default.createElement(
         'span',
-        { style: _this.props.style },
+        { style: _this.props.style,
+          className: _this.props.className },
         translation
       );
     }, _temp), _possibleConstructorReturn(_this, _ret);
@@ -64,6 +67,7 @@ var Translate = function (_BaseComponent) {
 Translate.propTypes = {
   value: _react2.default.PropTypes.string.isRequired,
   dangerousHTML: _react2.default.PropTypes.bool,
+  className: _react2.default.PropTypes.string,
   /**
    * Optional styling
    */

--- a/build/lib/Translate.js
+++ b/build/lib/Translate.js
@@ -6,6 +6,8 @@ Object.defineProperty(exports, "__esModule", {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -31,35 +33,35 @@ var Translate = function (_BaseComponent) {
   _inherits(Translate, _BaseComponent);
 
   function Translate() {
-    var _ref;
-
-    var _temp, _this, _ret;
-
     _classCallCheck(this, Translate);
 
-    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-      args[_key] = arguments[_key];
-    }
+    return _possibleConstructorReturn(this, (Translate.__proto__ || Object.getPrototypeOf(Translate)).apply(this, arguments));
+  }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Translate.__proto__ || Object.getPrototypeOf(Translate)).call.apply(_ref, [this].concat(args))), _this), _this.otherProps = function () {
-      var result = _extends({}, _this.props);
+  _createClass(Translate, [{
+    key: 'otherProps',
+    value: function otherProps() {
+      var result = _extends({}, this.props);
       delete result.value;
       return result;
-    }, _this.render = function () {
-      var translation = _I18n2.default._translate(_this.props.value, _this.otherProps());
-      if (_this.props.dangerousHTML) {
-        return _react2.default.createElement('span', { style: _this.props.style,
-          className: _this.props.className,
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var translation = _I18n2.default._translate(this.props.value, this.otherProps());
+      if (this.props.dangerousHTML) {
+        return _react2.default.createElement('span', { style: this.props.style,
+          className: this.props.className,
           dangerouslySetInnerHTML: { __html: translation } });
       }
       return _react2.default.createElement(
         'span',
-        { style: _this.props.style,
-          className: _this.props.className },
+        { style: this.props.style,
+          className: this.props.className },
         translation
       );
-    }, _temp), _possibleConstructorReturn(_this, _ret);
-  }
+    }
+  }]);
 
   return Translate;
 }(_Base2.default);

--- a/src/lib/Localize.jsx
+++ b/src/lib/Localize.jsx
@@ -27,7 +27,7 @@ export default class Localize extends BaseComponent {
     ),
   };
 
-  render = () => {
+  render() {
     const localization = I18n._localize(
       this.props.value,
       this.props.dateFormat

--- a/src/lib/Localize.jsx
+++ b/src/lib/Localize.jsx
@@ -14,6 +14,7 @@ export default class Localize extends BaseComponent {
       React.PropTypes.object]).isRequired,
     options: React.PropTypes.object,
     dateFormat: React.PropTypes.string,
+    className: React.PropTypes.string,
     dangerousHTML: React.PropTypes.bool,
     /**
      * Optional styling
@@ -34,8 +35,11 @@ export default class Localize extends BaseComponent {
         : this.props.options
     );
     if (this.props.dangerousHTML) {
-      return <span style={this.props.style} dangerouslySetInnerHTML={{ __html: localization }} />;
+      return <span style={this.props.style}
+                   className={this.props.className}
+                   dangerouslySetInnerHTML={{ __html: localization }} />;
     }
-    return <span style={this.props.style}>{localization}</span>;
+    return <span style={this.props.style}
+                 className={this.props.className}>{localization}</span>;
   }
 }

--- a/src/lib/Translate.jsx
+++ b/src/lib/Translate.jsx
@@ -6,6 +6,7 @@ import I18n from './I18n';
 import BaseComponent from './Base';
 
 export default class Translate extends BaseComponent {
+
   static propTypes = {
     value: React.PropTypes.string.isRequired,
     dangerousHTML: React.PropTypes.bool,
@@ -21,13 +22,13 @@ export default class Translate extends BaseComponent {
     ),
   };
 
-  otherProps = () => {
+  otherProps() {
     const result = { ...this.props };
     delete result.value;
     return result;
-  };
+  }
 
-  render = () => {
+  render() {
     const translation = I18n._translate(this.props.value, this.otherProps());
     if (this.props.dangerousHTML) {
       return <span style={this.props.style}

--- a/src/lib/Translate.jsx
+++ b/src/lib/Translate.jsx
@@ -9,6 +9,7 @@ export default class Translate extends BaseComponent {
   static propTypes = {
     value: React.PropTypes.string.isRequired,
     dangerousHTML: React.PropTypes.bool,
+    className: React.PropTypes.string,
     /**
      * Optional styling
      */
@@ -24,13 +25,16 @@ export default class Translate extends BaseComponent {
     const result = { ...this.props };
     delete result.value;
     return result;
-  }
+  };
 
   render = () => {
     const translation = I18n._translate(this.props.value, this.otherProps());
     if (this.props.dangerousHTML) {
-      return <span style={this.props.style} dangerouslySetInnerHTML={{ __html: translation }} />;
+      return <span style={this.props.style}
+                   className={this.props.className}
+                   dangerouslySetInnerHTML={{ __html: translation }} />;
     }
-    return <span style={this.props.style}>{translation}</span>;
+    return <span style={this.props.style}
+                 className={this.props.className}>{translation}</span>;
   }
 }


### PR DESCRIPTION
Hi,
I'm making this PR because I think that `<Translate/>` and `<Localize/>` components could use `className` attribute to avoid some useless nested html.

BEFORE: 
```js
<span className="someclass" >
  <Translate value="not_nice"/>
</span>
```

AFTER: 
```js
<Translate className="someclass" value="nicer"/>
```

Seems to be a nice to have feature. 😉 